### PR TITLE
[8.0][IMP] Modifications in document approval.

### DIFF
--- a/document_page_approval/__init__.py
+++ b/document_page_approval/__init__.py
@@ -1,4 +1,4 @@
-# -*- encoding: utf-8 -*-
+# coding: utf-8
 ##############################################################################
 #
 #    OpenERP, Open Source Management Solution

--- a/document_page_approval/__openerp__.py
+++ b/document_page_approval/__openerp__.py
@@ -1,4 +1,4 @@
-# -*- encoding: utf-8 -*-
+# coding: utf-8
 ##############################################################################
 #
 #    OpenERP, Open Source Management Solution
@@ -22,7 +22,7 @@
 {
     'name': 'Document Page Approval',
     'version': '8.0.1.0.0',
-    "author": "Savoir-faire Linux,Odoo Community Association (OCA)",
+    "author": "Savoir-faire Linux,Odoo Community Association (OCA),Vauxoo",
     "website": "http://www.savoirfairelinux.com",
     "license": "AGPL-3",
     'category': 'Knowledge Management',

--- a/document_page_approval/document_page_view.xml
+++ b/document_page_approval/document_page_view.xml
@@ -41,6 +41,11 @@
                         <field name="approved_uid" />
                     </group>
                 </field>
+                <xpath expr="//field[@name='name']" position="before">
+                    <div class="oe_right">
+                        <field name="history_state" class="oe_inline" widget="kanban_state_selection" readonly="1"/>
+                    </div>
+                </xpath>
             </field>
         </record>
 
@@ -87,6 +92,17 @@
                     <field name="is_parent_approval_required"
                            invisible="1" />
                 </field>
+            </field>
+        </record>
+
+        <record id="view_doc_page_inherit_history_approved_tree" model="ir.ui.view">
+            <field name="name">view.doc.page.inherit.history.approved.tree</field>
+            <field name="model">document.page</field>
+            <field name="inherit_id" ref="document_page.view_wiki_tree"/>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='name']" position="after">
+                    <field name="history_approved"/>
+                </xpath>
             </field>
         </record>
     </data>

--- a/document_page_approval/i18n/es.po
+++ b/document_page_approval/i18n/es.po
@@ -34,11 +34,19 @@ msgid ""
 msgstr "\n<p>Hola,</p>\n\n<p>La página \"${object.page_id.name}\" ha sido modificada y necesita tu aprobación.</p>\n\n<p>Puedes revisar la nueva versión aquí: <a href=\"${object.get_page_url}\">${object.get_page_url}</a></p>\n\n<p>Que tenga un buen día.<br/>\n--<br/>\nOdoo</p>\n            "
 
 #. module: document_page_approval
+#: help:document.page,history_state:0
+msgid "* Approved - If all histories of this document are approved.\n"
+"* Not all approved - If at least an history related to this document is not approved."
+msgstr "* Aprobado - Si todas las historias relacionadas a este documento están aprobadas.\n"
+"* No todo aprobado - Si al menos una de las historias relacionadas a este documento no ha sido aprobada."
+
+#. module: document_page_approval
 #: view:document.page.history:document_page_approval.wiki_history_form_inherit
 msgid "Approve"
 msgstr "Aprobar"
 
 #. module: document_page_approval
+#: selection:document.page,history_state:0
 #: selection:document.page.history,state:0
 msgid "Approved"
 msgstr "Aprobado"
@@ -76,6 +84,11 @@ msgid "Draft"
 msgstr "Borrador"
 
 #. module: document_page_approval
+#: field:document.page,history_state:0
+msgid "History state"
+msgstr "Estado Historias"
+
+#. module: document_page_approval
 #: model:email.template,subject:document_page_approval.email_template_new_draft_need_approval
 msgid "New version of \"${object.page_id.name}\" to approve"
 msgstr "Nueva versión de \"${object.page_id.name}\" para aprobar"
@@ -87,9 +100,19 @@ msgid "New version of the document %s approved."
 msgstr "Nueva versión del documento %s aprobada."
 
 #. module: document_page_approval
+#: selection:document.page,history_state:0
+msgid "Not all approved"
+msgstr "No todo aprobado"
+
+#. module: document_page_approval
 #: field:document.page,approval_required:0
 msgid "Require approval"
 msgstr "Requiere aprobación"
+
+#. module: document_page_approval
+#: field:document.page,history_approved:0
+msgid "Revision state"
+msgstr "Estado de revisión"
 
 #. module: document_page_approval
 #: field:document.page.history,state:0

--- a/document_page_approval/tests/__init__.py
+++ b/document_page_approval/tests/__init__.py
@@ -1,0 +1,11 @@
+# coding: utf-8
+############################################################################
+#    Module Writen For Odoo, Open Source Management Solution
+#
+#    Copyright (c) 2016 Vauxoo - http://www.vauxoo.com
+#    All Rights Reserved.
+#    info Vauxoo (info@vauxoo.com)
+#    coded by: Luis Torres <luis_t@vauxoo.com>
+#    planned by: Sabrina Romero <sabrina@vauxoo.com>
+############################################################################
+from . import test_history_state

--- a/document_page_approval/tests/test_history_state.py
+++ b/document_page_approval/tests/test_history_state.py
@@ -1,0 +1,54 @@
+# coding: utf-8
+############################################################################
+#    Module Writen For Odoo, Open Source Management Solution
+#
+#    Copyright (c) 2016 Vauxoo - http://www.vauxoo.com
+#    All Rights Reserved.
+#    info Vauxoo (info@vauxoo.com)
+#    Coded by: Luis Torres (luis_t@vauxoo.com)
+############################################################################
+from openerp.tests.common import TransactionCase
+
+
+class TestDocumentHistoryState(TransactionCase):
+
+    def setUp(self):
+        super(TestDocumentHistoryState, self).setUp()
+        self.page_obj = self.env['document.page']
+        self.history_obj = self.env['document.page.history']
+
+        self.category = self.env.ref('document_page.demo_category1')
+        self.approver_group = self.env.ref('base.group_document_approver_user')
+
+        self.category.write({
+            'approval_required': True,
+            'approver_gid': self.approver_group.id
+        })
+
+    def test_10_history_state_no_all_approved(self):
+        """Create a new document, and not validate the history"""
+        page_id = self.page_obj.create({
+            'name': 'Page Demo',
+            'parent_id': self.category.id,
+            'content': 'First version in document',
+        })
+        self.assertEquals(
+            page_id.history_state, 'blocked',
+            'Error, history state must be No all approved, because histories '
+            'related are not approved')
+
+    def test_20_history_state_approve(self):
+        """Create a new document, and not validate the history"""
+        page_id = self.page_obj.create({
+            'name': 'Page Demo to Approve',
+            'parent_id': self.category.id,
+            'content': 'First version in document',
+        })
+        history_ids = self.history_obj.search([
+            ('page_id', '=', page_id.id)
+        ])
+        history_ids.signal_workflow('page_approval_approve')
+        self.assertEquals(
+            page_id.history_state, 'done',
+            'Error, history state must be Approved, because histories '
+            'related are approved')

--- a/document_page_approval_levels/README.rst
+++ b/document_page_approval_levels/README.rst
@@ -1,0 +1,84 @@
+
+.. image:: https://img.shields.io/badge/licence-LGPL--3-blue.svg
+    :alt: License: LGPL-3
+
+Document Page Approval Levels
+=============================
+
+This module:
+  - Add the model approver.document.page.item, to allow set approvers in
+    document page and document history
+  - Add field approver_item_ids in document page to allow set the users
+    that need approve the histories created by the page. (If you update the
+    users list the system renders the histories that are not approved. )
+  - Add field approver_item_ids in document history, to allow approve the
+    history to users that are assigned in the document page.
+    Note: Only the user assigned to the item could approve it.
+  - Added validation to only show the valida button in history when all
+    items are approveds.
+  - When a user is select in an item, this user is added as follower in
+    the document page.
+  - Change the template that is send when is created a new history for a
+    document.
+  - When a user approve an item, is added a notification in the page, with the
+    next message: "The page has been approved by $USER "
+  - Added two new levels in knowledge group, (Approver and Manager)
+    The actually group User only can read, write and create pages.
+    The user approver have access to Pages, Categories and Histories.
+    The manager user have access to all menus in Knowledge.
+
+.. contents::
+
+Installation
+============
+
+To install this module, you need to:
+
+- Not special pre-installation is required, just install as a regular Odoo
+  module:
+
+  - Download this module from `Vauxoo/knowledge
+    <https://github.com/vauxoo/knowledge>`_
+  - Add the repository folder into your odoo addons-path.
+  - Go to ``Settings > Module list`` search for the current name and click in
+    ``Install`` button.
+
+Configuration
+=============
+
+To configure this module, you need to:
+
+* There is not special configuration for this module.
+
+Bug Tracker
+===========
+
+Bugs are tracked on
+`GitHub Issues <https://github.com/Vauxoo/knowledge/issues>`_.
+In case of trouble, please check there if your issue has already been reported.
+If you spotted it first, help us smashing it by providing a detailed and
+welcomed feedback
+`here <https://github.com/Vauxoo/knowledge/issues/new?body=module:%20
+document_page_approval_levels%0Aversion:%20
+8.0.2.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_
+
+Credits
+=======
+
+**Contributors**
+
+* Sabrina Romero <sabrina@vauxoo.com> (Planner/Auditor)
+* Luis Torres <luis_t@vauxoo.com> (Developer)
+
+Maintainer
+==========
+
+.. image:: https://s3.amazonaws.com/s3.vauxoo.com/description_logo.png
+   :alt: Vauxoo
+   :target: https://www.vauxoo.com
+   :width: 200
+
+This module is maintained by the Vauxoo.
+
+To contribute to this module, please visit https://www.vauxoo.com.
+

--- a/document_page_approval_levels/__init__.py
+++ b/document_page_approval_levels/__init__.py
@@ -1,0 +1,11 @@
+# coding: utf-8
+############################################################################
+#    Module Writen For Odoo, Open Source Management Solution
+#
+#    Copyright (c) 206 Vauxoo - http://www.vauxoo.com
+#    All Rights Reserved.
+#    info Vauxoo (info@vauxoo.com)
+#    coded by: Luis Torres <luis_t@vauxoo.com>
+#    planned by: Sabrina Romero <sabrina@vauxoo.com>
+############################################################################
+from . import models

--- a/document_page_approval_levels/__openerp__.py
+++ b/document_page_approval_levels/__openerp__.py
@@ -1,0 +1,40 @@
+# coding: utf-8
+############################################################################
+#    Module Writen For Odoo, Open Source Management Solution
+#
+#    Copyright (c) 2016 Vauxoo - http://www.vauxoo.com
+#    All Rights Reserved.
+#    info Vauxoo (info@vauxoo.com)
+#    coded by: Luis Torres <luis_t@vauxoo.com>
+#    planned by: Sabrina Romero<sabrina@vauxoo.com>
+############################################################################
+{
+    "name": "Document page approval levels",
+    "version": "8.0.0.0.1",
+    "author": "Vauxoo",
+    "category": "Knowledge Management",
+    "website": "http://www.vauxoo.com/",
+    "license": "AGPL-3",
+    "depends": [
+        "base_action_rule",
+        "document_page_approval",
+    ],
+    "demo": [
+        "demo/res_users.xml",
+    ],
+    "data": [
+        "security/res_groups.xml",
+        "security/ir.model.access.csv",
+        "data/action_server_data.xml",
+        "data/notification_template.xml",
+        "views/document_page_item_view.xml",
+        "views/document_page_view.xml",
+        "views/document_page_history_view.xml",
+    ],
+    "test": [],
+    "js": [],
+    "css": [],
+    "qweb": [],
+    "installable": True,
+    "auto_install": False
+}

--- a/document_page_approval_levels/data/action_server_data.xml
+++ b/document_page_approval_levels/data/action_server_data.xml
@@ -1,0 +1,35 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<openerp>
+    <data noupdate="1">
+
+           <record model="ir.actions.server" id="update_approvers_action">
+            <field name="name">Update approvers in histories</field>
+            <field name="model_id" eval="ref('document_page.model_document_page')"/>
+            <field name="state">code</field>
+            <field name="condition"></field>
+            <field name="sequence">5</field>
+            <field name="code">
+# Available locals:
+#  - time, datetime, dateutil: Python libraries
+#  - env: Odoo Environement
+#  - model: Model of the record on which the action is triggered
+#  - object: Record on which the action is triggered if there is one, otherwise None
+#  - workflow: Workflow engine
+#  - Warning: Warning Exception to use with raise
+# To return an action, assign: action = {...}
+env['document.page.history'].search([('page_id', 'in', object.ids), ('state', '=', 'draft')]).update_approver_items()
+            </field>
+        </record>
+
+        <record model="base.action.rule" id="action_rule_write_items_document_page">
+            <field name="name">Update approvers in histories</field>
+            <field name="model_id" eval="ref('document_page.model_document_page')"/>
+            <field name="sequence">0</field>
+            <field name="active">True</field>
+            <field name="kind">on_create_or_write</field>
+            <field name="server_action_ids" eval="[(6, 0, [ref('document_page_approval_levels.update_approvers_action')])]"/>
+        </record>
+
+
+    </data>
+</openerp>

--- a/document_page_approval_levels/data/notification_template.xml
+++ b/document_page_approval_levels/data/notification_template.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<openerp>
+
+    <!-- Allow user to make upgrade-proof customizations to email template -->
+
+    <data noupdate="1">
+
+        <record id="email_template_new_history_need_approval"
+                model="email.template">
+            <field name="name">Automated new history need approval Notification Mail</field>
+            <field name="email_from">${object.create_uid.company_id.email or 'noreply@localhost.com'}</field>
+            <field name="subject">"${object.page_id.name}"</field>
+            <field name="email_to">${object.get_followers()}</field>
+            <field name="model_id" ref="model_document_page_history"/>
+            <field name="auto_delete" eval="True"/>
+            <field name="lang">${object.create_uid.partner_id.lang}</field>
+            <field name="body_html"><![CDATA[
+<p>New document to approve: <a href="${object.get_page_url}">${object.get_page_url}</a></p>]]>
+            </field>
+        </record>
+
+    </data>
+</openerp>

--- a/document_page_approval_levels/demo/res_users.xml
+++ b/document_page_approval_levels/demo/res_users.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" ?>
+<openerp>
+    <data noupdate="1">
+
+        <record id="document_page_user" model="res.users" context="{'no_reset_password': True}">
+            <field name="name">Document page user</field>
+            <field name="login">page_user</field>
+            <field name="password">1234</field>
+            <field name="email">page_user@yourcompany.com</field>
+            <field name="company_id" ref="base.main_company"/>
+            <field name="company_ids" eval="[(4, ref('base.main_company'))]"/>
+            <field name="groups_id" eval="[(6,0,[ref('base.group_user'), ref('base.group_document_user')])]"/>
+        </record>
+
+        <record id="document_page_approver" model="res.users" context="{'no_reset_password': True}">
+            <field name="name">Document page approver</field>
+            <field name="login">page_approver</field>
+            <field name="password">1234</field>
+            <field name="email">page_approver@yourcompany.com</field>
+            <field name="company_id" ref="base.main_company"/>
+            <field name="company_ids" eval="[(4, ref('base.main_company'))]"/>
+            <field name="groups_id" eval="[(6,0,[ref('base.group_user'), ref('document_page_approval_levels.group_document_approver')])]"/>
+        </record>
+
+        <record id="document_page_manager" model="res.users" context="{'no_reset_password': True}">
+            <field name="name">Document page manager</field>
+            <field name="login">page_manager</field>
+            <field name="password">1234</field>
+            <field name="email">page_manager@yourcompany.com</field>
+            <field name="company_id" ref="base.main_company"/>
+            <field name="company_ids" eval="[(4, ref('base.main_company'))]"/>
+            <field name="groups_id" eval="[(6,0,[ref('base.group_user'), ref('document_page_approval_levels.group_document_manager')])]"/>
+        </record>
+
+
+    </data>
+</openerp>

--- a/document_page_approval_levels/i18n/es.po
+++ b/document_page_approval_levels/i18n/es.po
@@ -1,0 +1,202 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#   * document_page_approval_levels
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-06-01 18:58+0000\n"
+"PO-Revision-Date: 2016-06-01 18:58+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: document_page_approval_levels
+#: model:email.template,body_html:document_page_approval_levels.email_template_new_history_need_approval
+msgid "\n"
+"<p>New document to approve: <a href=\"${object.get_page_url}\">${object.get_page_url}</a></p>\n"
+"            "
+msgstr "\n"
+"<p>Nuevo documento para aprobar: <a href=\"${object.get_page_url}\">${object.get_page_url}</a></p>\n"
+"            "
+
+#. module: document_page_approval_levels
+#: model:email.template,subject:document_page_approval_levels.email_template_new_history_need_approval
+msgid "\"${object.page_id.name}\""
+msgstr "\"${object.page_id.name}\""
+
+#. module: document_page_approval_levels
+#: code:addons/document_page_approval_levels/models/document_page_history.py:58
+#, python-format
+msgid "<div>New document to approve.</div>"
+msgstr "<div>Nuevo documento para aprobar.</div>"
+
+#. module: document_page_approval_levels
+#: view:approver.document.page.item:document_page_approval_levels.view_approver_document_page_items_form
+#: view:approver.document.page.item:document_page_approval_levels.view_approver_document_page_items_tree
+msgid "Approve"
+msgstr "Aprobar"
+
+#. module: document_page_approval_levels
+#: field:approver.document.page.item,approved:0
+msgid "Approved"
+msgstr "Aprobado"
+
+#. module: document_page_approval_levels
+#: model:res.groups,name:document_page_approval_levels.group_document_approver
+msgid "Approver"
+msgstr "Aprobador"
+
+#. module: document_page_approval_levels
+#: view:approver.document.page.item:document_page_approval_levels.view_approver_document_page_items_form
+#: view:approver.document.page.item:document_page_approval_levels.view_approver_document_page_items_tree
+#: view:document.page:document_page_approval_levels.document_page_form_approver_inherit
+#: model:ir.actions.act_window,name:document_page_approval_levels.action_page_approver_items
+msgid "Approver Items"
+msgstr "Aprobadores"
+
+#. module: document_page_approval_levels
+#: field:document.page,approver_item_ids:0
+#: field:document.page.history,approver_item_ids:0
+msgid "Approver items"
+msgstr "Aprobadores"
+
+#. module: document_page_approval_levels
+#: view:document.page:document_page_approval_levels.document_page_form_approver_inherit
+#: view:document.page.history:document_page_approval_levels.document_history_form_approver_inherit
+msgid "Approvers"
+msgstr "Aprobadores"
+
+#. module: document_page_approval_levels
+#: view:approver.document.page.item:document_page_approval_levels.view_approver_document_page_items_form
+#: view:approver.document.page.item:document_page_approval_levels.view_approver_document_page_items_tree
+msgid "Click here if you are sure of approve, it will mark this as 'approved'"
+msgstr "Presiona aquí si estas seguro de aprobar, esto marcará el registro como 'Aprobado'"
+
+#. module: document_page_approval_levels
+#: field:approver.document.page.item,create_uid:0
+msgid "Created by"
+msgstr "Creado por"
+
+#. module: document_page_approval_levels
+#: field:approver.document.page.item,create_date:0
+msgid "Created on"
+msgstr "Creado en"
+
+#. module: document_page_approval_levels
+#: field:approver.document.page.item,display_name:0
+msgid "Display Name"
+msgstr "Nombre a mostrar"
+
+#. module: document_page_approval_levels
+#: field:approver.document.page.item,document_id:0
+msgid "Document"
+msgstr "Documento"
+
+#. module: document_page_approval_levels
+#: model:ir.model,name:document_page_approval_levels.model_document_page
+msgid "Document Page"
+msgstr "Página de documento"
+
+#. module: document_page_approval_levels
+#: model:ir.model,name:document_page_approval_levels.model_document_page_history
+msgid "Document Page History"
+msgstr "Historia de página de documento"
+
+#. module: document_page_approval_levels
+#: field:approver.document.page.item,history_id:0
+msgid "History"
+msgstr "Historia"
+
+#. module: document_page_approval_levels
+#: field:approver.document.page.item,id:0
+msgid "ID"
+msgstr "ID"
+
+#. module: document_page_approval_levels
+#: help:approver.document.page.item,approved:0
+msgid "Indicate if this item already was approved"
+msgstr "Indica si este registro ya fue aprobado"
+
+#. module: document_page_approval_levels
+#: code:addons/document_page_approval_levels/models/document_page_history.py:84
+#: code:addons/document_page_approval_levels/models/document_page_item.py:37
+#, python-format
+msgid "Invalid Action!"
+msgstr "Acción invalida!"
+
+#. module: document_page_approval_levels
+#: field:approver.document.page.item,__last_update:0
+msgid "Last Modified on"
+msgstr "Última modificación en"
+
+#. module: document_page_approval_levels
+#: field:approver.document.page.item,write_uid:0
+msgid "Last Updated by"
+msgstr "Última actualización por"
+
+#. module: document_page_approval_levels
+#: field:approver.document.page.item,write_date:0
+msgid "Last Updated on"
+msgstr "Última actualización por"
+
+#. module: document_page_approval_levels
+#: code:addons/document_page_approval_levels/models/document_page_item.py:53
+#, python-format
+msgid "Only can assign an item by the same user by document."
+msgstr "Únicamente se puede asignar un registro para el mismo usuario por documento."
+
+#. module: document_page_approval_levels
+#: code:addons/document_page_approval_levels/models/document_page_item.py:35
+#, python-format
+msgid "Only the user assigned to this item can validate it."
+msgstr "Únicamente el usuario asignado al registro puede validarlo."
+
+#. module: document_page_approval_levels
+#: code:addons/document_page_approval_levels/models/document_page_history.py:84
+#, python-format
+msgid "Only users validators can edit the content in this history."
+msgstr "Solo los usuarios validadores pueden editar el contenido en esta historia."
+
+#. module: document_page_approval_levels
+#: field:document.page.history,to_approve_ok:0
+msgid "To approve ok"
+msgstr "Listo para aprobar"
+
+#. module: document_page_approval_levels
+#: model:ir.actions.server,name:document_page_approval_levels.update_approvers_action
+msgid "Update approvers in histories"
+msgstr "Actualizar aprobadores en las historias"
+
+#. module: document_page_approval_levels
+#: field:approver.document.page.item,user_id:0
+#: model:res.groups,name:document_page_approval_levels.group_document_user_limit
+msgid "User"
+msgstr "Usuario"
+
+#. module: document_page_approval_levels
+#: help:approver.document.page.item,user_id:0
+msgid "User of committee that need approve partially the histories generated from this page."
+msgstr "Usuario del comité que necesita aprobar parcialmente las historias generadas para esta página."
+
+
+#. module: document_page_approval_levels
+#: help:document.page.history,approver_item_ids:0
+msgid "Users and state in items that need partial approbation in this history"
+msgstr "Usuarios y estado de los registros que necesitan ser aprobados en esta historia"
+
+#. module: document_page_approval_levels
+#: help:document.page,approver_item_ids:0
+msgid "Users that partially approve the histories of this page."
+msgstr "Usuarios que parcialmente aprueban las historias de esta página."
+
+#. module: document_page_approval_levels
+#: view:document.page.history:document_page_approval_levels.document_history_form_approver_inherit_button
+msgid "{'invisible':['|', ('to_approve_ok', '=', False)]}"
+msgstr "{'invisible':['|', ('to_approve_ok', '=', False)]}"
+
+

--- a/document_page_approval_levels/i18n/es_MX.po
+++ b/document_page_approval_levels/i18n/es_MX.po
@@ -1,0 +1,17 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#   * document_page_approval_levels
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-06-01 18:58+0000\n"
+"PO-Revision-Date: 2016-06-01 18:58+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+

--- a/document_page_approval_levels/i18n/es_VE.po
+++ b/document_page_approval_levels/i18n/es_VE.po
@@ -1,0 +1,17 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#   * document_page_approval_levels
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-06-01 18:58+0000\n"
+"PO-Revision-Date: 2016-06-01 18:58+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+

--- a/document_page_approval_levels/models/__init__.py
+++ b/document_page_approval_levels/models/__init__.py
@@ -1,0 +1,13 @@
+# coding: utf-8
+############################################################################
+#    Module Writen For Odoo, Open Source Management Solution
+#
+#    Copyright (c) 206 Vauxoo - http://www.vauxoo.com
+#    All Rights Reserved.
+#    info Vauxoo (info@vauxoo.com)
+#    coded by: Luis Torres <luis_t@vauxoo.com>
+#    planned by: Sabrina Romero <sabrina@vauxoo.com>
+############################################################################
+from . import document_page_item
+from . import document_page
+from . import document_page_history

--- a/document_page_approval_levels/models/document_page.py
+++ b/document_page_approval_levels/models/document_page.py
@@ -1,0 +1,25 @@
+# coding: utf-8
+############################################################################
+#    Module Writen For Odoo, Open Source Management Solution
+#
+#    Copyright (c) 206 Vauxoo - http://www.vauxoo.com
+#    All Rights Reserved.
+#    info Vauxoo (info@vauxoo.com)
+#    coded by: Luis Torres <luis_t@vauxoo.com>
+#    planned by: Sabrina Romero <sabrina@vauxoo.com>
+############################################################################
+from openerp import models, fields
+
+
+class DocumentPage(models.Model):
+    """This class is use to manage Document."""
+    _inherit = 'document.page'
+
+    approver_item_ids = fields.One2many(
+        'approver.document.page.item', 'document_id', 'Approver items',
+        help='Users that partially approve the histories of this page.')
+
+    def create_history(self, page_id, content):
+        if self._context.get('from_history', False):
+            return False
+        return super(DocumentPage, self).create_history(page_id, content)

--- a/document_page_approval_levels/models/document_page_history.py
+++ b/document_page_approval_levels/models/document_page_history.py
@@ -1,0 +1,98 @@
+# coding: utf-8
+############################################################################
+#    Module Writen For Odoo, Open Source Management Solution
+#
+#    Copyright (c) 206 Vauxoo - http://www.vauxoo.com
+#    All Rights Reserved.
+#    info Vauxoo (info@vauxoo.com)
+#    coded by: Luis Torres <luis_t@vauxoo.com>
+#    planned by: Sabrina Romero <sabrina@vauxoo.com>
+############################################################################
+from openerp import models, fields, api, SUPERUSER_ID, _
+from openerp.exceptions import Warning as UserError
+
+
+class DocumentPageHistory(models.Model):
+    """This class is use to manage Document History."""
+    _inherit = 'document.page.history'
+
+    approver_item_ids = fields.One2many(
+        'approver.document.page.item', 'history_id', 'Approver items',
+        help='Users and state in items that need partial approbation in '
+        'this history')
+
+    to_approve_ok = fields.Boolean(compute='_get_approver_ok')
+
+    @api.depends('approver_item_ids.approved')
+    def _get_approver_ok(self):
+        """Return True if all Approver Items are approved."""
+        for history in self:
+            if all([item.approved for item in history.approver_item_ids]):
+                history.to_approve_ok = True
+
+    @api.multi
+    def update_approver_items(self):
+        """Refresh items by user based in page_id"""
+        for history in self:
+            users_approver = history.approver_item_ids.filtered(
+                "approved").mapped('user_id')
+            users_page = history.page_id.approver_item_ids.mapped('user_id')
+            history.approver_item_ids.unlink()
+            for user in users_page:
+                self.env['approver.document.page.item'].create({
+                    'history_id': history.id,
+                    'user_id': user.id,
+                    'approved': user.id in users_approver.ids})
+        return True
+
+    def page_approval_draft(self):
+        """Overwrite method to change template to send mail"""
+        self.write({'state': 'draft'})
+        template_id = self.env['ir.model.data'].get_object_reference(
+            'document_page_approval_levels',
+            'email_template_new_history_need_approval')[1]
+        for page in self:
+            if page.is_parent_approval_required:
+                self.env['email.template'].browse(template_id).send_mail(
+                    page.id, force_send=True)
+                msg = _('<div>New document to approve.</div>')
+                page.page_id.message_post(
+                    type='comment', body=msg)
+        return True
+
+    @api.multi
+    def get_followers(self):
+        follower_obj = self.env['mail.followers']
+        fol_ids = follower_obj.sudo(SUPERUSER_ID).search([
+            ('res_model', '=', 'document.page'),
+            ('res_id', '=', self.page_id.id)])
+        partner_ids = [
+            foll.partner_id.email for foll in fol_ids if foll.partner_id]
+        return ', '.join(map(str, partner_ids))
+
+    @api.multi
+    def write(self, values):
+        """Inherit to notify that content in history is changed."""
+        if 'content' in values:
+            self._history_content_updated()
+        return super(DocumentPageHistory, self).write(values)
+
+    @api.multi
+    def _history_content_updated(self):
+        """When is changed the content in document page history:
+            - Verify that the user is approver of the history
+            - Disapprove items approved in the history
+            - Send notification that the history was changed."""
+        if self._uid not in self.approver_item_ids.mapped('user_id').ids:
+            raise UserError(_('Invalid Action!'), _(
+                'Only users validators can edit the content in this history.'))
+        self.mapped('approver_item_ids').write({'approved': False})
+        self.page_approval_draft()
+
+    @api.multi
+    def page_approval_approved(self):
+        for history in self:
+            history.page_id.with_context(from_history=True).write(
+                {'content': history.content})
+        self.page_approval_draft()
+        return super(DocumentPageHistory, self).page_approval_approved()

--- a/document_page_approval_levels/models/document_page_item.py
+++ b/document_page_approval_levels/models/document_page_item.py
@@ -1,0 +1,59 @@
+# coding: utf-8
+############################################################################
+#    Module Writen For Odoo, Open Source Management Solution
+#
+#    Copyright (c) 206 Vauxoo - http://www.vauxoo.com
+#    All Rights Reserved.
+#    info Vauxoo (info@vauxoo.com)
+#    coded by: Luis Torres <luis_t@vauxoo.com>
+#    planned by: Sabrina Romero <sabrina@vauxoo.com>
+############################################################################
+from openerp import models, fields, api, _
+from openerp.exceptions import Warning as UserError, ValidationError
+
+
+class ApproverDocumentPageItem(models.Model):
+    _name = 'approver.document.page.item'
+
+    user_id = fields.Many2one(
+        'res.users', 'User', required=True, help='User of committee that need '
+        'approve partially the histories generated from this page.')
+
+    approved = fields.Boolean(
+        help='Indicate if this item already was approved')
+
+    document_id = fields.Many2one('document.page', 'Document')
+
+    history_id = fields.Many2one('document.page.history', 'History')
+
+    @api.multi
+    def approve(self):
+        """Approve a document page and send an note in the register."""
+        for item in self:
+            if item.approved:
+                continue
+            if item._uid != item.user_id.id:
+                raise UserError(
+                    _('Invalid Action!'),
+                    _('Only the user assigned to this item can validate it.'))
+            item.write({'approved': True})
+            msg = (
+                '<div><b>The page has been approved by %s .</b></div>' %
+                item.user_id.name)
+            item.history_id.page_id.message_post(
+                type='comment', body= _(msg))
+
+    @api.constrains('user_id', 'document_id')
+    def _check_unique_user_document(self):
+        if all([self.user_id, self.document_id, self.search([
+                ('user_id', '=', self.user_id.id),
+                ('document_id', '=', self.document_id.id),
+                ('id', '!=', self.id)])]):
+            raise ValidationError(_(
+                'Only can assign an item by the same user by document.'))
+
+    @api.model
+    def create(self, vals):
+        res = super(ApproverDocumentPageItem, self).create(vals)
+        res.document_id.message_subscribe_users(res.user_id.id)
+        return res

--- a/document_page_approval_levels/models/document_page_item.py
+++ b/document_page_approval_levels/models/document_page_item.py
@@ -41,7 +41,7 @@ class ApproverDocumentPageItem(models.Model):
                 '<div><b>The page has been approved by %s .</b></div>' %
                 item.user_id.name)
             item.history_id.page_id.message_post(
-                type='comment', body= _(msg))
+                type='comment', body=_(msg))
 
     @api.constrains('user_id', 'document_id')
     def _check_unique_user_document(self):

--- a/document_page_approval_levels/security/ir.model.access.csv
+++ b/document_page_approval_levels/security/ir.model.access.csv
@@ -1,0 +1,6 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+document_page_approval_items,document.page.item,model_approver_document_page_item,,1,1,1,1
+document_page_approval_levels_user,document.page.user,model_document_page,base.group_document_user,1,1,1,0
+document_page_history_user,document.page.history.user,model_document_page_history,base.group_document_user,1,1,0,0
+document_page.document_page,document.page,model_document_page,base.group_user,1,1,1,0
+

--- a/document_page_approval_levels/security/res_groups.xml
+++ b/document_page_approval_levels/security/res_groups.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data noupdate="0">
+
+        <record id="group_document_approver" model="res.groups">
+            <field name="name">Approver</field>
+            <field name="category_id" ref="base.module_category_knowledge_management"/>
+            <field name="implied_ids" eval="[(4, ref('base.group_document_user'))]"/>
+        </record>
+
+        <record id="group_document_manager" model="res.groups">
+            <field name="name">Manager</field>
+            <field name="category_id" ref="base.module_category_knowledge_management"/>
+            <field name="implied_ids" eval="[(4, ref('group_document_approver'))]"/>
+        </record>
+
+    </data>
+</openerp>

--- a/document_page_approval_levels/tests/__init__.py
+++ b/document_page_approval_levels/tests/__init__.py
@@ -1,0 +1,11 @@
+# coding: utf-8
+############################################################################
+#    Module Writen For Odoo, Open Source Management Solution
+#
+#    Copyright (c) 2016 Vauxoo - http://www.vauxoo.com
+#    All Rights Reserved.
+#    info Vauxoo (info@vauxoo.com)
+#    coded by: Luis Torres <luis_t@vauxoo.com>
+#    planned by: Sabrina Romero <sabrina@vauxoo.com>
+############################################################################
+from . import test_approval_levels

--- a/document_page_approval_levels/tests/test_approval_levels.py
+++ b/document_page_approval_levels/tests/test_approval_levels.py
@@ -1,0 +1,197 @@
+# coding: utf-8
+############################################################################
+#    Module Writen For Odoo, Open Source Management Solution
+#
+#    Copyright (c) 2016 Vauxoo - http://www.vauxoo.com
+#    All Rights Reserved.
+#    info Vauxoo (info@vauxoo.com)
+#    Coded by: Luis Torres (luis_t@vauxoo.com)
+############################################################################
+from openerp.tests.common import TransactionCase
+from openerp.exceptions\
+    import Warning as UserError, ValidationError, AccessError
+
+
+class TestDocumentApprovalLevelState(TransactionCase):
+
+    def setUp(self):
+        super(TestDocumentApprovalLevelState, self).setUp()
+        self.page_obj = self.env['document.page']
+        self.history_obj = self.env['document.page.history']
+        self.item_obj = self.env['approver.document.page.item']
+        self.follower_obj = self.env['mail.followers']
+
+        self.category = self.env.ref('document_page.demo_category1')
+        self.approver_group = self.env.ref('base.group_document_approver_user')
+        self.document_user = self.env.ref(
+            'document_page_approval_levels.document_page_user')
+        self.document_approver = self.env.ref(
+            'document_page_approval_levels.document_page_approver')
+        self.document_manager = self.env.ref(
+            'document_page_approval_levels.document_page_manager')
+
+        self.category.write({
+            'approval_required': True,
+            'approver_gid': self.approver_group.id
+        })
+
+    def test_10_verify_followers(self):
+        """Create a new document with items and verify users as followers"""
+        page_id = self.page_obj.create({
+            'name': 'Page Demo',
+            'parent_id': self.category.id,
+            'content': 'First version in document',
+            'approver_item_ids': [(0, 0, {
+                'user_id': self.document_approver.id,
+            }), (0, 0, {
+                'user_id': self.document_manager.id,
+            })]
+        })
+        fol_ids = self.follower_obj.search([
+            ('res_model', '=', 'document.page'),
+            ('res_id', '=', page_id.id)
+        ])
+        partners = [follow.partner_id.id for follow in fol_ids]
+        self.assertTrue(
+            self.document_approver.partner_id.id in partners,
+            'User approver not in followers')
+        self.assertTrue(
+            self.document_manager.partner_id.id in partners,
+            'User manager not in followers')
+
+    def test_20_approve_item(self):
+        """Create a new document with items and the user approve it"""
+        page_id = self.page_obj.create({
+            'name': 'Page Demo',
+            'parent_id': self.category.id,
+            'content': 'First version in document',
+            'approver_item_ids': [(0, 0, {
+                'user_id': self.document_approver.id,
+            })]
+        })
+        histories = page_id.history_ids
+        item = self.item_obj.search([
+            ('history_id', 'in', histories.ids),
+        ])
+        with self.assertRaisesRegexp(
+                UserError,
+                'Only the user assigned to this item can validate it.'):
+            item.sudo(self.document_manager.id).approve()
+        item.sudo(self.document_approver.id).approve()
+        self.assertTrue(item.approved, 'Item not approved')
+
+    def test_30_create_new_item_in_document(self):
+        """Create a new document with an items, after add a new and check that
+        is updated in the history"""
+        page = self.page_obj.create({
+            'name': 'Page Demo',
+            'parent_id': self.category.id,
+            'content': 'First version in document',
+            'approver_item_ids': [(0, 0, {
+                'user_id': self.document_manager.id,
+            })]
+        })
+        histories = page.history_ids
+        items1 = self.item_obj.search([
+            ('history_id', 'in', histories.ids),
+        ])
+        page.write({
+            'approver_item_ids': [(0, 0, {
+                'user_id': self.document_approver.id})]
+        })
+        items2 = self.item_obj.search([
+            ('history_id', 'in', histories.ids),
+        ])
+        self.assertNotEquals(
+            len(items1), len(items2),
+            'Items in history are not updated')
+
+    def test_40_new_item_document_with_item_approvea(self):
+        """Verify that when is add a new item, approved items are not removed
+        """
+        page = self.page_obj.create({
+            'name': 'Page Demo',
+            'parent_id': self.category.id,
+            'content': 'First version in document',
+            'approver_item_ids': [(0, 0, {
+                'user_id': self.document_approver.id,
+            })]
+        })
+        histories = page.history_ids
+        item = self.item_obj.search([
+            ('history_id', 'in', histories.ids),
+        ])
+        item.sudo(self.document_approver.id).approve()
+        page.write({
+            'approver_item_ids': [(0, 0, {
+                'user_id': self.document_manager.id})]
+        })
+        item = self.item_obj.search([
+            ('history_id', 'in', histories.ids),
+            ('approved', '=', True)
+        ])
+        self.assertTrue(item, 'Item approved not found')
+
+    def test_50_approve_item(self):
+        """Create two items to the same user"""
+        with self.assertRaisesRegexp(
+                ValidationError,
+                'Only can assign an item by the same user by document.'):
+            self.page_obj.create({
+                'name': 'Page Demo',
+                'parent_id': self.category.id,
+                'content': 'First version in document',
+                'approver_item_ids': [(0, 0, {
+                    'user_id': self.document_approver.id,
+                }), (0, 0, {
+                    'user_id': self.document_approver.id,
+                })]
+            })
+
+    def test_60_try_delete_page_user(self):
+        """Try delete a page with limit user"""
+        page = self.page_obj.sudo(self.document_user.id).create({
+            'name': 'Page Demo',
+            'parent_id': self.category.id,
+            'content': 'First version in document',
+            'approver_item_ids': [(0, 0, {
+                'user_id': self.document_approver.id,
+            })]})
+        with self.assertRaisesRegexp(
+                AccessError,
+                'Sorry, you are not allowed to delete this document.'):
+            page.sudo(self.document_user.id).unlink()
+
+    def test_70_changed_content_in_history(self):
+        """Test that update content in history"""
+        page = self.page_obj.create({
+            'name': 'Page Demo to Update',
+            'parent_id': self.category.id,
+            'content': 'First version in docume',
+            'approver_item_ids': [(0, 0, {
+                'user_id': self.document_approver.id,
+            }), (0, 0, {
+                'user_id': self.document_manager.id,
+            })]
+        })
+        histories = page.history_ids
+        item = self.item_obj.search([
+            ('history_id', 'in', histories.ids),
+            ('user_id', '=', self.document_approver.id)
+        ])
+        item.sudo(self.document_approver.id).approve()
+        histories.sudo(self.document_manager.id).write({
+            'content': 'First version in document'
+        })
+        items = self.item_obj.search([
+            ('history_id', 'in', histories.ids),
+            ('approved', '=', True)
+        ])
+        self.assertFalse(items, 'The Items must be disapproved')
+        for item in histories.approver_item_ids:
+            item.sudo(item.user_id.id).approve()
+        histories.signal_workflow('page_approval_approve')
+        self.assertEquals(
+            page.content, histories.content, 'Content not updated')
+        self.assertEquals(
+            len(page.history_ids), 1, 'Histories created mistakenly')

--- a/document_page_approval_levels/views/document_page_history_view.xml
+++ b/document_page_approval_levels/views/document_page_history_view.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<openerp>
+    <data>
+        <record id="document_history_form_approver_inherit" model="ir.ui.view">
+            <field name="name">document.history.form.approver.inherit</field>
+            <field name="model">document.page.history</field>
+            <field name="inherit_id" ref="document_page.wiki_history_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='content']" position="after">
+                    <field name="to_approve_ok" invisible="1"/>
+                    <separator string="Approvers"/>
+                    <field name="approver_item_ids" readonly="True"/>
+                </xpath>
+            </field>
+        </record>
+
+        <record id="document_history_form_approver_inherit_button" model="ir.ui.view">
+            <field name="name">document.history.form.approver.inherit.button</field>
+            <field name="model">document.page.history</field>
+            <field name="inherit_id" ref="document_page_approval.wiki_history_form_inherit"/>
+            <field name="arch" type="xml">
+                <xpath expr="//button[@name='page_approval_approve']" position="attributes">
+                    <attribute name="attrs">{'invisible':['|', ('to_approve_ok', '=', False)]}</attribute>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</openerp>

--- a/document_page_approval_levels/views/document_page_item_view.xml
+++ b/document_page_approval_levels/views/document_page_item_view.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0"?>
+<openerp>
+    <data>
+        <record id="view_approver_document_page_items_tree" model="ir.ui.view">
+            <field name="name">view.approver.document.page.items.tree</field>
+            <field name="model">approver.document.page.item</field>
+            <field name="arch" type="xml">
+                <tree string="Approver Items">
+                    <field name="user_id"/>
+                    <field name="approved"/>
+                    <button icon="gtk-apply" name="approve" string="Approve" type="object" help="Click here if you are sure of approve, it will mark this as 'approved'" attrs="{'invisible': [('approved', '=', True)]}"/>
+                </tree>
+            </field>
+        </record>
+
+        <record id="view_approver_document_page_items_form" model="ir.ui.view">
+            <field name="name">view.approver.document.page.items.form</field>
+            <field name="model">approver.document.page.item</field>
+            <field name="arch" type="xml">
+                <form string="Approver Items">
+                    <header>
+                        <button icon="gtk-apply" name="approve" string="Approve" type="object" help="Click here if you are sure of approve, it will mark this as 'approved'" attrs="{'invisible': [('approved', '=', True)]}"/>
+                    </header>
+                    <sheet>
+                        <group>
+                            <field name="user_id"/>
+                            <field name="approved" readonly="1"/>
+                        </group>
+                    </sheet>
+                </form>
+            </field>
+        </record>
+
+        <record id="action_page_approver_items" model="ir.actions.act_window">
+            <field name="name">Approver Items</field>
+            <field name="res_model">approver.document.page.item</field>
+            <field name="view_type">form</field>
+            <field name="view_mode">tree,form</field>
+            <field name="view_id" ref="view_approver_document_page_items_tree"/>
+        </record>
+
+    </data>
+</openerp>

--- a/document_page_approval_levels/views/document_page_view.xml
+++ b/document_page_approval_levels/views/document_page_view.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0"?>
+<openerp>
+    <data>
+        <record id="document_page_form_approver_inherit" model="ir.ui.view">
+            <field name="name">document.page.form.approver.inherit</field>
+            <field name="model">document.page</field>
+            <field name="inherit_id" ref="document_page.view_wiki_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='content']" position="after">
+                    <separator string="Approvers"/>
+                    <field name="approver_item_ids">
+                        <tree string="Approver Items" editable="bottom">
+                            <field name="user_id"/>
+                        </tree>
+                        <form string="Approver Items">
+                            <field name="user_id"/>
+                        </form>
+                    </field>
+                </xpath>
+            </field>
+        </record>
+
+        <menuitem name="Knowledge"
+            id="knowledge.menu_document"
+            groups="base.group_system,base.group_document_user"/>
+
+        <menuitem id="document_page.menu_category"
+            name="Categories"
+            sequence="20"
+            parent="document_page.menu_wiki"
+            action="document_page.action_category"
+            groups="document_page_approval_levels.group_document_approver"/>
+
+        <menuitem id="document_page.menu_page"
+            parent="document_page.menu_wiki"
+            groups="base.group_document_user"
+            name="Pages"
+            action="document_page.action_page"
+            sequence="10" />
+
+        <menuitem id="document_page.menu_page_history"
+            parent="document_page.menu_wiki"
+            name="Pages history"
+            action="document_page.action_history"
+            sequence="30"
+            groups="base.group_no_one,document_page_approval_levels.group_document_approver" />
+
+        <act_window
+            id="document_page.action_related_page_history"
+            context="{'search_default_page_id': [active_id], 'default_page_id': active_id}"
+            domain="[('page_id','=',active_id)]"
+            name="Page History"
+            res_model="document.page.history"
+            src_model="document.page"
+            groups="document_page_approval_levels.group_document_approver"/>
+
+        <menuitem name="Configuration" id="knowledge.menu_document_configuration"
+            parent="knowledge.menu_document" sequence="50"
+            groups="document_page_approval_levels.group_document_manager"/>
+
+    </data>
+</openerp>

--- a/document_page_code/README.rst
+++ b/document_page_code/README.rst
@@ -1,0 +1,71 @@
+
+.. image:: https://img.shields.io/badge/licence-LGPL--3-blue.svg
+    :alt: License: LGPL-3
+
+Document Page Code
+==================
+
+This module:
+ - Add field Internal code in document page model.
+
+.. contents::
+
+Installation
+============
+
+To install this module, you need to:
+
+- Not special pre-installation is required, just install as a regular Odoo
+  module:
+
+  - Download this module from `Vauxoo/knowledge
+    <https://github.com/vauxoo/knowledge>`_
+  - Add the repository folder into your odoo addons-path.
+  - Go to ``Settings > Module list`` search for the current name and click in
+    ``Install`` button.
+
+Configuration
+=============
+
+To configure this module, you need to:
+
+* There is not special configuration for this module.
+
+Usage
+=====
+
+Bug Tracker
+===========
+
+Bugs are tracked on
+`GitHub Issues <https://github.com/Vauxoo/knowledge/issues>`_.
+In case of trouble, please check there if your issue has already been reported.
+If you spotted it first, help us smashing it by providing a detailed and
+welcomed feedback
+`here <https://github.com/Vauxoo/knowledge/issues/new?body=module:%20
+document_page_code%0Aversion:%20
+8.0.2.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_
+
+TODO
+====
+
+Credits
+=======
+
+**Contributors**
+
+* Sabrina Romero <sabrina@vauxoo.com> (Planner/Auditor)
+* Luis Torres <luis_t@vauxoo.com> (Developer)
+
+Maintainer
+==========
+
+.. image:: https://s3.amazonaws.com/s3.vauxoo.com/description_logo.png
+   :alt: Vauxoo
+   :target: https://www.vauxoo.com
+   :width: 200
+
+This module is maintained by the Vauxoo.
+
+To contribute to this module, please visit https://www.vauxoo.com.
+

--- a/document_page_code/__init__.py
+++ b/document_page_code/__init__.py
@@ -1,0 +1,11 @@
+# coding: utf-8
+############################################################################
+#    Module Writen For Odoo, Open Source Management Solution
+#
+#    Copyright (c) 206 Vauxoo - http://www.vauxoo.com
+#    All Rights Reserved.
+#    info Vauxoo (info@vauxoo.com)
+#    coded by: Luis Torres <luis_t@vauxoo.com>
+#    planned by: Sabrina Romero <sabrina@vauxoo.com>
+############################################################################
+from . import models

--- a/document_page_code/__openerp__.py
+++ b/document_page_code/__openerp__.py
@@ -1,0 +1,31 @@
+# coding: utf-8
+############################################################################
+#    Module Writen For Odoo, Open Source Management Solution
+#
+#    Copyright (c) 2016 Vauxoo - http://www.vauxoo.com
+#    All Rights Reserved.
+#    info Vauxoo (info@vauxoo.com)
+#    coded by: Luis Torres <luis_t@vauxoo.com>
+#    planned by: Sabrina Romero<sabrina@vauxoo.com>
+############################################################################
+{
+    "name": "Document Page Code",
+    "version": "8.0.0.0.1",
+    "author": "Vauxoo",
+    "category": "Knowledge Management",
+    "website": "http://www.vauxoo.com/",
+    "license": "AGPL-3",
+    "depends": [
+        "document_page"
+    ],
+    "demo": [],
+    "data": [
+        "views/document_page.xml",
+    ],
+    "test": [],
+    "js": [],
+    "css": [],
+    "qweb": [],
+    "installable": True,
+    "auto_install": False
+}

--- a/document_page_code/i18n/es.po
+++ b/document_page_code/i18n/es.po
@@ -1,0 +1,34 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#   * document_page_code
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-05-27 22:28+0000\n"
+"PO-Revision-Date: 2016-05-27 22:28+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: document_page_code
+#: model:ir.model,name:document_page_code.model_document_page
+msgid "Document Page"
+msgstr "Página de documento"
+
+#. module: document_page_code
+#: view:document.page:document_page_code.document_page_form_code_inherit
+#: field:document.page,code:0
+msgid "Internal code"
+msgstr "Código interno"
+
+#. module: document_page_code
+#: view:document.page:document_page_code.document_page_form_code_inherit
+msgid "oe_inline"
+msgstr "oe_inline"
+
+

--- a/document_page_code/i18n/es_MX.po
+++ b/document_page_code/i18n/es_MX.po
@@ -1,0 +1,16 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#   * document_page_code
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-05-27 22:28+0000\n"
+"PO-Revision-Date: 2016-05-27 22:28+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"

--- a/document_page_code/models/__init__.py
+++ b/document_page_code/models/__init__.py
@@ -1,0 +1,11 @@
+# coding: utf-8
+############################################################################
+#    Module Writen For Odoo, Open Source Management Solution
+#
+#    Copyright (c) 206 Vauxoo - http://www.vauxoo.com
+#    All Rights Reserved.
+#    info Vauxoo (info@vauxoo.com)
+#    coded by: Luis Torres <luis_t@vauxoo.com>
+#    planned by: Sabrina Romero <sabrina@vauxoo.com>
+############################################################################
+from . import document_page

--- a/document_page_code/models/document_page.py
+++ b/document_page_code/models/document_page.py
@@ -1,0 +1,18 @@
+# coding: utf-8
+############################################################################
+#    Module Writen For Odoo, Open Source Management Solution
+#
+#    Copyright (c) 206 Vauxoo - http://www.vauxoo.com
+#    All Rights Reserved.
+#    info Vauxoo (info@vauxoo.com)
+#    coded by: Luis Torres <luis_t@vauxoo.com>
+#    planned by: Sabrina Romero <sabrina@vauxoo.com>
+############################################################################
+from openerp import models, fields
+
+
+class DocumentPage(models.Model):
+    """This class is use to manage Document."""
+    _inherit = 'document.page'
+
+    code = fields.Char('Internal code')

--- a/document_page_code/views/document_page.xml
+++ b/document_page_code/views/document_page.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+<openerp>
+    <data>
+        <record id="document_page_form_code_inherit" model="ir.ui.view">
+            <field name="name">document.page.form.code.inherit</field>
+            <field name="model">document.page</field>
+            <field name="inherit_id" ref="document_page.view_wiki_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='name']" position="attributes">
+                    <attribute name="class">oe_inline</attribute>
+                </xpath>
+                <xpath expr="//field[@name='name']" position="before">
+                    <field name="code" class="oe_inline" placeholder="Internal code"/> -
+                </xpath>
+            </field>
+        </record>
+
+        <record id="document_page_tree_code_inherit" model="ir.ui.view">
+            <field name="name">document.page.tree.code.inherit</field>
+            <field name="model">document.page</field>
+            <field name="inherit_id" ref="document_page.view_wiki_tree"/>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='name']" position="before">
+                    <field name="code"/>
+                </xpath>
+            </field>
+        </record>
+
+        <record id="document_page_search_code_inherit" model="ir.ui.view">
+            <field name="name">document.page.search.code.inherit</field>
+            <field name="model">document.page</field>
+            <field name="inherit_id" ref="document_page.view_wiki_filter"/>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='parent_id']" position="before">
+                    <field name="code"/>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</openerp>


### PR DESCRIPTION
[HU #1050](https://www.vauxoo.com/web#id=1050&view_type=form&model=user.story&menu_id=557&action=726)
CA #1, 2, 3, 4, 6

[IMP][document_page_approval]
    Added field history_state in document page with widget
    kanban_state_selection, to indicate if all the histories related
    with the document are approved.
    Added test to check the new feature.
[ADD][document_page_code]Added module that add field internal code in
    document page model.
    Added in search view the new field code
[ADD][document_page_approval_levels]
    Added module that set approvers in document.page.
    Added model approver.document.page.item with fields user_id and
    approver to allow have levels to approve an history.
    Hide button approve in history when are not approved all items in
    it.
    Added as followers all users setted in the page as committee.
    Send notification to followers when is created a new history.
    Added profiles to users in knowledge
    Added users demo
    Added tests in module
